### PR TITLE
feat|fix: Deal with the case with ","

### DIFF
--- a/GongSaeng/Presentation/Community/Model/Community.swift
+++ b/GongSaeng/Presentation/Community/Model/Community.swift
@@ -55,7 +55,9 @@ struct Community: Decodable {
         self.numberOfComments = try container.decode(Int.self, forKey: .numberOfComments)
         
         do {
-            self.thumbnailImageFilename = try container.decodeIfPresent(String.self, forKey: .thumbnailImageFilename)
+            if let decodedFileName = try container.decodeIfPresent(String.self, forKey: .thumbnailImageFilename) {
+                self.thumbnailImageFilename = decodedFileName.components(separatedBy: ",").first
+            }
         } catch {
             self.thumbnailImageFilename = try container.decodeIfPresent([String].self, forKey: .thumbnailImageFilename)?.first
         }


### PR DESCRIPTION
이미지 파일 이름이 "25,26"과 같이 오는 경우도 있었으므로 처리합니다.