### PR TITLE
fix: Make IBOutlet optional

### DIFF
--- a/GongSaeng/Presentation/Home/HomeViewController.swift
+++ b/GongSaeng/Presentation/Home/HomeViewController.swift
@@ -12,14 +12,18 @@ class HomeViewController: UIViewController {
     var user: User? {
         didSet {
             print("DEBUG: HomeViewController get user property")
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self, let user = self.user else { return }
-                self.affiliationLabel.text = user.department
+            DispatchQueue.main.async { [unowned self] in
+                self.setAffiliationLabel()
             }
         }
     }
     
-    @IBOutlet weak var affiliationLabel: UILabel!
+    @IBOutlet weak var affiliationLabel: UILabel?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setAffiliationLabel()
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -31,5 +35,13 @@ class HomeViewController: UIViewController {
         super.viewWillDisappear(animated)
         
         navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+}
+
+extension HomeViewController {
+    func setAffiliationLabel() {
+        if let user = self.user, let affiliationLabel = self.affiliationLabel {
+            affiliationLabel.text = user.department
+        }
     }
 }


### PR DESCRIPTION
강제 언래핑하면 에러가 나는 경우도 있으므로 수정합니다.
affiliationLabel 값 설정하는 부분을 함수로 따로 빼내고, 만약 User 값이 지정되었을 때 못했다면 viewDidLoad에서 지정하도록 합니다.