### PR TITLE
Feature/thunder

### DIFF
--- a/GongSaeng/Network/ThunderNetworkManager.swift
+++ b/GongSaeng/Network/ThunderNetworkManager.swift
@@ -118,66 +118,6 @@ let exampleMyThunders: [MyThunder] = [
         numberOfComments: 10)
 ]
 
-final class ThunderNetworkManager1 {
-    static func fetchThunderDetail(index: Int, completion: @escaping(ThunderDetail) -> Void) {
-        // 네트워크 로직
-        let urlComponents = URLComponents(string: "\(SERVER_URL)/thunder/\(index)")
-        guard let url = urlComponents?.url else { return }
-     
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        let dataTask = URLSession.shared.dataTask(with: request) {data, response, error in
-            guard error == nil,
-                  let response = response as? HTTPURLResponse,
-                  let data = data,
-                  let thunderDetail = try? JSONDecoder().decode(ThunderDetail.self, from: data) else {
-                      print("ERROR: URLSession data task \(error?.localizedDescription ?? "")")
-                      return
-                  }
-            
-            switch response.statusCode {
-            case (200...299):
-                print("DEBUG: Network succeded")
-                DispatchQueue.main.async {
-                    completion(thunderDetail)
-                }
-            case (400...499):
-                print("""
-                    ERROR: Client ERROR \(response.statusCode)
-                    Response: \(response)
-                """)
-            case (500...599):
-                print("""
-                    ERROR: Server ERROR \(response.statusCode)
-                    Response: \(response)
-                """)
-            default:
-                print("""
-                    ERROR: \(response.statusCode)
-                    Response: \(response)
-                """)
-            }
-        }
-        
-        dataTask.resume()
-        
-//        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { // 임시 더미데이터
-//            DispatchQueue.main.async {
-//                completion(exampleThunderDetail)
-//            }
-//        }
-    }
-    
-    static func fetchComments(index: Int, completion: @escaping([Comment]) -> Void) {
-        // 네트워크 로직
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { // 임시 더미데이터
-            DispatchQueue.main.async {
-                completion(exampleComments)
-            }
-        }
-    }
-}
-
 final class ThunderNetworkManager {
     private let session: URLSession
 
@@ -187,14 +127,6 @@ final class ThunderNetworkManager {
 
     func fetchThunders(page: Int, by order: SortingOrder, region: String) -> Single<Result<[Thunder], NetworkError>> {
         print("DEBUG: Called fetchThunders().. ")
-//        return Single<Result<[Thunder], Error>>.create { single -> Disposable in
-//            DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
-//                DispatchQueue.main.async {
-//                    single(.success(.success(exampleThunders)))
-//                }
-//            }
-//            return Disposables.create()
-//        }
         
         let regionData = region.split(separator: "/").map { String($0) }
         let metapolis = regionData[0]
@@ -237,18 +169,6 @@ final class ThunderNetworkManager {
             return Disposables.create()
         }
     }
-
-//    static func fetchThunderDetail(index: Int) -> Single<Result<ThunderDetail, Error>> {
-//        print("DEBUG: Called fetchThunderDetail()..")
-//        return Single<Result<ThunderDetail, Error>>.create { single -> Disposable in
-//            DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
-//                DispatchQueue.main.async {
-//                    single(.success(.success(exampleThunderDetail)))
-//                }
-//            }
-//            return Disposables.create()
-//        }
-//    }
     
     func postThunder(meetingTime: String, place: String, placeURL: String, address: String, totalNum: String, title: String, contents: String, images: [UIImage], completion: @escaping(Bool) -> Void) {
         let regionData = address.split(separator: " ").map { String($0) }
@@ -317,6 +237,58 @@ final class ThunderNetworkManager {
             }
         }
         dataTask.resume()
+    }
+    
+    static func fetchThunderDetail(index: Int, completion: @escaping(ThunderDetail) -> Void) {
+        // 네트워크 로직
+        let urlComponents = URLComponents(string: "\(SERVER_URL)/thunder/\(index)")
+        guard let url = urlComponents?.url else { return }
+     
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let dataTask = URLSession.shared.dataTask(with: request) {data, response, error in
+            guard error == nil,
+                  let response = response as? HTTPURLResponse,
+                  let data = data,
+                  let thunderDetail = try? JSONDecoder().decode(ThunderDetail.self, from: data) else {
+                      print("ERROR: URLSession data task \(error?.localizedDescription ?? "")")
+                      return
+                  }
+            
+            switch response.statusCode {
+            case (200...299):
+                print("DEBUG: Network succeded")
+                DispatchQueue.main.async {
+                    completion(thunderDetail)
+                }
+            case (400...499):
+                print("""
+                    ERROR: Client ERROR \(response.statusCode)
+                    Response: \(response)
+                """)
+            case (500...599):
+                print("""
+                    ERROR: Server ERROR \(response.statusCode)
+                    Response: \(response)
+                """)
+            default:
+                print("""
+                    ERROR: \(response.statusCode)
+                    Response: \(response)
+                """)
+            }
+        }
+        
+        dataTask.resume()
+    }
+    
+    static func fetchComments(index: Int, completion: @escaping([Comment]) -> Void) {
+        // 네트워크 로직
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { // 임시 더미데이터
+            DispatchQueue.main.async {
+                completion(exampleComments)
+            }
+        }
     }
 }
 

--- a/GongSaeng/Network/ThunderNetworkManager.swift
+++ b/GongSaeng/Network/ThunderNetworkManager.swift
@@ -290,6 +290,44 @@ final class ThunderNetworkManager {
             }
         }
     }
+    
+    // TODO: Should replace to real
+    static func joinThunder(index: Int, completion: @escaping(Bool) -> Void) {
+        guard let request = URLRequest.getPOSTRequest(url: "\(SERVER_URL)/thunder/join",
+                                                      data: ["idx": index] as Dictionary<String, Any>) else { return }
+        
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard error == nil,
+                  let response = response as? HTTPURLResponse,
+                  let data = data else {
+                      print("ERROR: URLSession data task \(error?.localizedDescription ?? "")")
+                      return
+                  }
+            print(String(data: data, encoding: .utf8))
+            switch response.statusCode {
+            case (200...299):
+                print("DEBUG: joinThunder() data -> \(String(data: data, encoding: .utf8)!)")
+                let isSucceded = String(data: data, encoding: .utf8) == "true" ? true : false
+                completion(isSucceded)
+            case (400...499):
+                print("""
+                    ERROR: Client ERROR \(response.statusCode)
+                    Response: \(response)
+                """)
+            case (500...599):
+                print("""
+                    ERROR: Server ERROR \(response.statusCode)
+                    Response: \(response)
+                """)
+            default:
+                print("""
+                    ERROR: \(response.statusCode)
+                    Response: \(response)
+                """)
+            }
+        }
+        dataTask.resume()
+    }
 }
 
 private extension ThunderNetworkManager {

--- a/GongSaeng/Presentation/Thunder/Model/ThunderDetail.swift
+++ b/GongSaeng/Presentation/Thunder/Model/ThunderDetail.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ThunderDetail: Decodable {
+    var idx: Int
     var postingImagesFilename: [String]
     var title: String
     var writerImageFilename: String?
@@ -44,6 +45,7 @@ struct ThunderDetail: Decodable {
     private var participantsIntroduce: [String]
     
     enum CodingKeys: String, CodingKey {
+        case idx
         case postingImagesFilename = "contents_image"
         case title, contents, status
         case writerImageFilename = "writer_image"

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderView.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderView.swift
@@ -173,7 +173,7 @@ final class ThunderDetailHeaderView: UIView {
             attributes: [.font: UIFont.systemFont(ofSize: 17.0, weight: .heavy),
                          .foregroundColor: UIColor.white]), for: .normal)
         button.layer.cornerRadius = 8.0
-//        button.addTarget(self, action: #selector(<#T##@objc method#>), for: .touchUpInside)
+        button.addTarget(self, action: #selector(didTapJoinButton), for: .touchUpInside)
         return button
     }()
     
@@ -214,6 +214,17 @@ final class ThunderDetailHeaderView: UIView {
     }
     
     // MARK: Actions
+    @objc
+    private func didTapJoinButton() {
+        ThunderNetworkManager.joinThunder(index: viewModel.idx) { isSuccess in
+            if isSuccess {
+                
+            } else {
+                
+            }
+        }
+    }
+    
     @objc
     private func openMapLink() {
         if let url = viewModel.placeURL { UIApplication.shared.open(url, options: [:]) }

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderView.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderView.swift
@@ -236,6 +236,10 @@ final class ThunderDetailHeaderView: UIView {
         cell.updateImageHeight(height)
     }
     
+    func updateNumberOfComments(_ num: Int) {
+        numberOfCommentsLabel.text = "댓글 \(num)"
+    }
+    
     private func configure() {
         self.backgroundColor = .white
         titleLabel.text = viewModel.title

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderViewModel.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ThunderDetailHeaderViewModel {
+    var idx: Int
     var attachedImageURLs: [URL?]
     var title: String
     var writerImageURL: URL?
@@ -35,6 +36,7 @@ struct ThunderDetailHeaderViewModel {
     var numOfCommentsText: String
      
     init(thunderDetail: ThunderDetail) {
+        self.idx = thunderDetail.idx
         self.attachedImageURLs = (thunderDetail.postingImagesFilename)
             .map { URL(string: SERVER_IMAGE_URL + $0) }
         self.title = thunderDetail.title

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/ThunderDetailViewController.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/ThunderDetailViewController.swift
@@ -121,7 +121,7 @@ final class ThunderDetailViewController: UIViewController {
     
     // MARK: API
     private func fetchThunderDetail(index: Int) {
-        ThunderNetworkManager1.fetchThunderDetail(index: index) { [weak self] thunderDetail in
+        ThunderNetworkManager.fetchThunderDetail(index: index) { [weak self] thunderDetail in
             guard let self = self else { return }
             self.viewModel.thunderDetail = thunderDetail
             let headerView = ThunderDetailHeaderView(viewModel: ThunderDetailHeaderViewModel(thunderDetail: thunderDetail))
@@ -132,13 +132,6 @@ final class ThunderDetailViewController: UIViewController {
             self.fetchedPageList = []
             self.fetchComments(of: self.currentPage, shouldRefresh:  true)
         }
-        
-//        ThunderNetworkManager1.fetchComments(index: 0) { [weak self] comments in
-//            self?.commentList = comments
-//            DispatchQueue.main.async {
-//                self?.tableView.reloadData()
-//            }
-//        }
     }
     
     private func fetchComments(of page: Int, shouldRefresh: Bool = false) {

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/ThunderDetailViewController.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/ThunderDetailViewController.swift
@@ -155,6 +155,9 @@ final class ThunderDetailViewController: UIViewController {
             
             DispatchQueue.main.async {
                 self.tableView.reloadData()
+                if let headerView = self.tableView.tableHeaderView as? ThunderDetailHeaderView {
+                    headerView.updateNumberOfComments(comments.count)
+                }
             }
         }
     }


### PR DESCRIPTION
현재 서버에 thunder 관련 api가 없습니다.
api가 생기면 바로 이식 가능하도록 빠져 있던 로직을 추가합니다.
- 댓글 개수 업데이트
- `ThunderNetworkManager1` 삭제, 샘플 코드 삭제
- 번개 참가/취소 api 호출을 위한 변수 `idx` 추가
- 번개 참가 api 임시로 추가