### PR TITLE
Feature/refresh thunder

### DIFF
--- a/GongSaeng/Presentation/Thunder/ThunderListViewController/Subviews/ListView/ThunderListTableViewModel.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderListViewController/Subviews/ListView/ThunderListTableViewModel.swift
@@ -13,6 +13,7 @@ final class ThunderListTableViewModel {
     
     // MARK: Properties
     private let disposeBag = DisposeBag()
+    let thunderListRefreshNeeded = BehaviorRelay<Bool>(value: true)
     let thunderCellData = PublishSubject<[ThunderListCellViewModel]>()
     let tableViewItems: Driver<[ThunderSectionItem]>
     let itemSelected = PublishRelay<Int>()

--- a/GongSaeng/Presentation/Thunder/ThunderListViewController/ThunderListViewModel.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderListViewController/ThunderListViewModel.swift
@@ -37,8 +37,12 @@ final class ThunderListViewModel {
     
     init(_ model: ThunderListModel = ThunderListModel()) {
         let thundersResult = Observable
-            .combineLatest(currentPage, sortingOrder, selectedRegion)
-            .distinctUntilChanged { $0 == $1 }
+            .combineLatest(thunderListTableViewModel.thunderListRefreshNeeded,
+                           Observable.combineLatest(currentPage, sortingOrder, selectedRegion)
+                .distinctUntilChanged { $0 == $1 })
+            .map({
+                $0.1
+            })
             .map(model.fetchThunders)
             .flatMap { $0 }
             .share()

--- a/GongSaeng/Presentation/Thunder/ThunderListViewController/ThunderListViewModel.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderListViewController/ThunderListViewModel.swift
@@ -18,8 +18,6 @@ enum SortingOrder: String {
 final class ThunderListViewModel {
     private let disposeBag = DisposeBag()
     
-    let myThunders = BehaviorSubject<[ThunderDetailInfo]?>(value: nil)
-    
     // Subview's ViewModel
     let thunderListTopViewModel = ThunderListTopViewModel()
     let thunderListTableViewModel = ThunderListTableViewModel()
@@ -57,16 +55,6 @@ final class ThunderListViewModel {
             .bind(to: thunderListTableViewModel.thunderCellData)
             .disposed(by: disposeBag)
 
-        let myThundersResult = model.fetchMyThunders()
-        let myThundersValue = myThundersResult
-            .map(model.getMyThundersValue)
-            .asObservable()
-        
-        myThundersValue
-            .bind(to: myThunders)
-            .disposed(by: disposeBag)
-            
-        
         // UserDefaults(Singletone) -> ViewModel
         UserDefaults.standard.rx
             .observe(String.self, "region")
@@ -106,7 +94,10 @@ final class ThunderListViewModel {
         self.pushThunderView = thunderListTableViewModel.selectedIndex
         
         self.pushMyThunderView = myThunderButtonTapped
-            .withLatestFrom(myThunders)
+            .flatMap {
+                model.fetchMyThunders()
+                    .map(model.getMyThundersValue)
+            }
             .compactMap { $0 }
             .asSignal(onErrorJustReturn: [])
     }


### PR DESCRIPTION
## 참여번개보기
기존에 내 번개 리스트는 맨 처음 한 번만 요청을 보냅니다.
그러나 특정 번개에 참여 후에 내 번개를 보아도 추가되지 않는 문제가 있으므로, 버튼을 누를 때마다 로드 되어야 합니다.
따라서 버튼을 누를 때마다 데이터를 요청하도록 수정합니다.

## 번개 리스트 새로고침
번개 리스트를 끌어당겨서 새로고침하기 위해, 테이블 뷰 모델에 `thunderListRefreshNeeded`을 추가합니다.
정렬, 선택 지역이 바뀐 경우 말고도 끌어당긴 때도 옵저빙합니다.
끌어당기는 것과 정렬/지역 바꾸기는 둘이 구분되어야 하므로, 따로 묶어 냅니다.
끌어당기는 경우에는 이미 존재하는 정렬/지역 정보를 사용합니다.