### PR TITLE
Fix/bugs

### DIFF
--- a/GongSaeng.xcodeproj/project.pbxproj
+++ b/GongSaeng.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		AFE3A63028F5722B005C1EFB /* MyWritten.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE3A62F28F5722B005C1EFB /* MyWritten.swift */; };
 		AFE3A63228F57413005C1EFB /* MyComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE3A63128F57413005C1EFB /* MyComment.swift */; };
 		AFE3A63428F576B2005C1EFB /* MyCommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE3A63328F576B2005C1EFB /* MyCommentCell.swift */; };
+		AFEDA8D928F6CE3B004E242D /* EditProfileResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEDA8D828F6CE3B004E242D /* EditProfileResultModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -391,6 +392,7 @@
 		AFE3A62F28F5722B005C1EFB /* MyWritten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWritten.swift; sourceTree = "<group>"; };
 		AFE3A63128F57413005C1EFB /* MyComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyComment.swift; sourceTree = "<group>"; };
 		AFE3A63328F576B2005C1EFB /* MyCommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCommentCell.swift; sourceTree = "<group>"; };
+		AFEDA8D828F6CE3B004E242D /* EditProfileResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileResultModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -734,6 +736,7 @@
 			children = (
 				A76B9DAE2784694B006AF832 /* EditProfileViewController.swift */,
 				A76B9DB02784CD64006AF832 /* EditProfileViewModel.swift */,
+				AFEDA8D828F6CE3B004E242D /* EditProfileResultModel.swift */,
 			);
 			path = EditProfile;
 			sourceTree = "<group>";
@@ -1145,6 +1148,7 @@
 				3D5D59AA2652B11C0018FE63 /* RegisterViewController.swift in Sources */,
 				A709A2E7278563750038BB76 /* Register.swift in Sources */,
 				A719D09F27CFC1B6000A9388 /* MyThunder.swift in Sources */,
+				AFEDA8D928F6CE3B004E242D /* EditProfileResultModel.swift in Sources */,
 				A7EB35692786DB42001BCD03 /* ImageCacheManager.swift in Sources */,
 				3D2FBC062675FE6B00D2FF56 /* PublicViewController.swift in Sources */,
 				3D231A68266E44BA00080E9B /* Mate.swift in Sources */,

--- a/GongSaeng/Network/UserService.swift
+++ b/GongSaeng/Network/UserService.swift
@@ -56,7 +56,7 @@ struct UserService: NetworkManager {
             guard error == nil,
                   let response = response as? HTTPURLResponse,
                   let data = data,
-                  let returnValue = String(data: data, encoding: .utf8)  else {
+                  let returnValue = try? JSONDecoder().decode(EditProfileResultData.self, from: data) else {
                 print("ERROR: URLSession data task \(error?.localizedDescription ?? "")")
                 return
             }
@@ -64,9 +64,7 @@ struct UserService: NetworkManager {
             switch response.statusCode {
             case (200...299):
                 print("DEBUG: UserService.editProfile() response succeded..", returnValue)
-                let isSucceded = (returnValue == "false") ? false : true
-                let imageUrl = (isSucceded && (returnValue != "true")) ? returnValue : nil
-                completion(isSucceded, imageUrl)
+                completion(true, returnValue.data.profileImageURL)
             default:
                 handleError(response: response)
             }

--- a/GongSaeng/Presentation/MyPage/EditProfile/EditProfileResultModel.swift
+++ b/GongSaeng/Presentation/MyPage/EditProfile/EditProfileResultModel.swift
@@ -1,0 +1,18 @@
+//
+//  EditProfileResultModel.swift
+//  GongSaeng
+//
+//  Created by Yujin Cha on 2022/10/12.
+//
+
+struct EditProfileResultData: Decodable {
+    var data: EditProfileResult
+}
+
+struct EditProfileResult: Decodable {
+    var profileImageURL: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case profileImageURL = "profile_image_url"
+    }
+}

--- a/GongSaeng/Presentation/MyPage/EditProfile/EditProfileViewController.swift
+++ b/GongSaeng/Presentation/MyPage/EditProfile/EditProfileViewController.swift
@@ -126,6 +126,8 @@ final class EditProfileViewController: UIViewController {
             }
             print("DEBUG: isSucceded ->", isSucceded)
             UserService.fetchCurrentUser { user in
+                var user = user
+                user?.updateUser(nickName: nickName, job: job, introduce: introduce, profileImageFilename: imageUrl)
                 UserDefaults.standard.set(try? PropertyListEncoder().encode(user), forKey: "loginUser")
                 UserDefaults.standard.removeObject(forKey: "userImage")
                 if let imageUrl = imageUrl {

--- a/GongSaeng/Presentation/MyPage/ManageAccountInfo/ManageAccountViewController.swift
+++ b/GongSaeng/Presentation/MyPage/ManageAccountInfo/ManageAccountViewController.swift
@@ -99,6 +99,8 @@ class ManageAccountViewController: UIViewController {
                 return
             }
             UserService.fetchCurrentUser { user in
+                var user = user
+                user?.updateUser(name: name, phoneNumber: phoneNumber, email: email)
                 UserDefaults.standard.set(try? PropertyListEncoder().encode(user), forKey: "loginUser")
                 DispatchQueue.main.async {
                     self.showLoader(false)

--- a/GongSaeng/Presentation/MyPage/ManageAccountInfo/PasswordChangingViewController.swift
+++ b/GongSaeng/Presentation/MyPage/ManageAccountInfo/PasswordChangingViewController.swift
@@ -258,7 +258,6 @@ extension PasswordChangingViewController: BannerButtonInputAccessoryViewDelegate
                     let popUpTitle = "비밀번호 변경에 실패했어요. 현재 비밀번호를 알맞게 입력하셨는지 확인해 주세요"
                     let popUpViewController = PopUpViewController(contents: popUpTitle)
                     popUpViewController.modalPresentationStyle = .overCurrentContext
-                    let rootViewController = self.navigationController?.viewControllers.first
                     self.present(popUpViewController, animated: false, completion: nil)
                 }
             }

--- a/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderViewModel.swift
+++ b/GongSaeng/Presentation/Thunder/ThunderDetailViewController/Subviews/ThunderDetailHeaderViewModel.swift
@@ -84,7 +84,7 @@ struct ThunderDetailHeaderViewModel {
         if user.nickname == thunderDetail.writerNickname {
             self.joinStatus = .owner
         } else if participantsProfile.contains(where: { profile in
-            user.nickname == profile.nickname
+            user.id == profile.id
         }){
             self.joinStatus = .canCancel
         } else {


### PR DESCRIPTION
- 장터/챌린지 게시판에서 참여 상태를 위해 닉네임을 사용했었으나, 닉네임은 변하므로 변하지 않는 아이디 값을 사용합니다.
- 프로필 수정 후에 바로 유저 정보를 다시 읽어올 경우 바뀌지 않은 것이 오는 문제가 있었습니다. 따라서 서버 명세를 바꿔 프로필 이미지 url을 다시 보내주는 것으로 바꾸었습니다. 프론트 단에서 직접 수정하여 넣어줍니다.